### PR TITLE
fix bug where keyboard does not appear on iOS6

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -264,7 +264,6 @@
 	_passcodeTextField.delegate = self;
     _passcodeTextField.secureTextEntry = YES;
     _passcodeTextField.translatesAutoresizingMaskIntoConstraints = NO;
-	[_passcodeTextField becomeFirstResponder];
     
     [self.view setNeedsUpdateConstraints];
 }
@@ -273,6 +272,8 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 //    NSLog(@"layout %@", [self.view performSelector:@selector(recursiveDescription)]);
+    [_passcodeTextField becomeFirstResponder];
+
 }
 
 


### PR DESCRIPTION
Sometimes the keyboard does not appear on iOS6. this is fixed by ensuring `viewDidLoad` and `viewDidAppear` finish before calling `[_passcodeTextField becomeFirstResponder]`
