### PR TITLE
Fixes issue rolandleth/LTHPasscodeViewController#72

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -760,8 +760,10 @@
 			newCenter = CGPointMake(mainWindow.center.x,
 									mainWindow.center.y + self.navigationController.navigationBar.frame.size.height / 2);
 		}
-        if (![UIApplication sharedApplication].statusBarHidden) {
-            newCenter.y += [[UIApplication sharedApplication] statusBarFrame].size.height;
+        
+        if (![[UIApplication sharedApplication] isStatusBarHidden]) {
+            newCenter.y += MIN([[UIApplication sharedApplication] statusBarFrame].size.height,
+                               [[UIApplication sharedApplication] statusBarFrame].size.width);
         }
         
 		if (animated) {


### PR DESCRIPTION
[[UIApplication sharedApplication] statusBarFrame].size.height returns 1024 in lanscape (iOS7.1). This caused the passcode view to be off screen. I didn't test this change on iOS6.
