### PR TITLE
Spanish strings corrections + Touch ID

### DIFF
--- a/Localizations/es.lproj/LTHPasscodeViewController.strings
+++ b/Localizations/es.lproj/LTHPasscodeViewController.strings
@@ -24,3 +24,5 @@
 "1 Passcode Failed Attempt" = "1 intento fallido";
 
 "%i Passcode Failed Attempts" = "%i intentos fallidos";
+
+"Unlock using Touch ID" = "Desbloquea usando Touch ID";


### PR DESCRIPTION
Hi, im from Spain and i found your spanish translation a bit weird.

I checked the Apple oficial translation (is easy to check this, just change your ios device to spanish, go to settings->passcode and try to activate/modify/etc.. your passcode and look at the strings). 

I modified those strings to be the same than Apple uses, which are more natural to native spanish speaker. Now, the translation is almost exactly the same one Apple is using, and the only thing I didn't want to change is the word "contraseña" (password). Apple uses the word "código" instead, which is a more accurate translation of "passcode". I preferred to leave the word "contraseña" (password) because it fits better for both, simple and complex passwords! However, if you feel the word passcode fits better, then i suggest you to change all the "contraseña" for "código"
