### PR TITLE
Fix to make sure nav bar disappears when unlocking

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1316,7 +1316,7 @@ options:NSNumericSearch] != NSOrderedAscending)
     }
 	
 	// Make sure nav bar for logout is off the screen
-    if (!_isUsingNavbar) {
+    if (_isUsingNavbar) {
         [self.navBar removeFromSuperview];
         self.navBar = nil;
     }


### PR DESCRIPTION
Otherwise the nav bar remains on screen after unlocking with a log out button