### PR TITLE
Do not initialise always isSimple to YES

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -178,7 +178,7 @@
 /**
  @brief The string to be used as username for the "isSimple" in the Keychain.
  */
-@property (nonatomic, strong) NSString  *keychainIsSimpleUsername;
+@property (nonatomic, strong) NSString  *keychainPasscodeIsSimpleUsername;
 /**
  @brief The string to be used as service name for all the Keychain entries.
  */

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -176,6 +176,10 @@
  */
 @property (nonatomic, strong) NSString  *keychainTimerDurationUsername;
 /**
+ @brief The string to be used as username for the "isSimple" in the Keychain.
+ */
+@property (nonatomic, strong) NSString  *keychainIsSimpleUsername;
+/**
  @brief The string to be used as service name for all the Keychain entries.
  */
 @property (nonatomic, strong) NSString  *keychainServiceName;

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -261,6 +261,13 @@ options:NSNumericSearch] != NSOrderedAscending)
                       forServiceName:_keychainServiceName
                       updateExisting:YES
                                error:nil];
+    
+    
+    [LTHKeychainUtils storeUsername:_keychainIsSimpleUsername
+                        andPassword:[NSString stringWithFormat:@"%@", [self isSimple] ? @"YES" : @"NO"]
+                     forServiceName:_keychainServiceName
+                     updateExisting:YES
+                              error:nil];
 }
 
 
@@ -1483,7 +1490,16 @@ options:NSNumericSearch] != NSOrderedAscending)
 
 
 - (void)_commonInit {
-	_isSimple = YES;
+    if ([LTHKeychainUtils getPasswordForUsername:_keychainIsSimpleUsername
+                                  andServiceName:_keychainServiceName
+                                           error:nil]) {
+        _isSimple = [[LTHKeychainUtils getPasswordForUsername:_keychainIsSimpleUsername
+                                               andServiceName:_keychainServiceName
+                                                        error:nil] boolValue];
+    } else {
+        _isSimple = YES;
+    }
+    
 	[self _loadDefaults];
 }
 
@@ -1569,6 +1585,7 @@ options:NSNumericSearch] != NSOrderedAscending)
     _keychainTimerStartUsername = @"demoPasscodeTimerStart";
     _keychainServiceName = @"demoServiceName";
     _keychainTimerDurationUsername = @"passcodeTimerDuration";
+    _keychainIsSimpleUsername = @"passcodeIsSimple";
 }
 
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -263,7 +263,7 @@ options:NSNumericSearch] != NSOrderedAscending)
                                error:nil];
     
     
-    [LTHKeychainUtils storeUsername:_keychainIsSimpleUsername
+    [LTHKeychainUtils storeUsername:_keychainPasscodeIsSimpleUsername
                         andPassword:[NSString stringWithFormat:@"%@", [self isSimple] ? @"YES" : @"NO"]
                      forServiceName:_keychainServiceName
                      updateExisting:YES
@@ -1490,10 +1490,10 @@ options:NSNumericSearch] != NSOrderedAscending)
 
 
 - (void)_commonInit {
-    if ([LTHKeychainUtils getPasswordForUsername:_keychainIsSimpleUsername
+    if ([LTHKeychainUtils getPasswordForUsername:_keychainPasscodeIsSimpleUsername
                                   andServiceName:_keychainServiceName
                                            error:nil]) {
-        _isSimple = [[LTHKeychainUtils getPasswordForUsername:_keychainIsSimpleUsername
+        _isSimple = [[LTHKeychainUtils getPasswordForUsername:_keychainPasscodeIsSimpleUsername
                                                andServiceName:_keychainServiceName
                                                         error:nil] boolValue];
     } else {
@@ -1585,7 +1585,7 @@ options:NSNumericSearch] != NSOrderedAscending)
     _keychainTimerStartUsername = @"demoPasscodeTimerStart";
     _keychainServiceName = @"demoServiceName";
     _keychainTimerDurationUsername = @"passcodeTimerDuration";
-    _keychainIsSimpleUsername = @"passcodeIsSimple";
+    _keychainPasscodeIsSimpleUsername = @"passcodeIsSimple";
 }
 
 


### PR DESCRIPTION
If a user changes the passcode from simple to complex and then he kills the app, the next time he launches the app will ask for a simple passcode instead for a complex passcode. So it is needed save the `isSimple` between different runs.