### PR TITLE
Fix invisible keyboard after dimissing TouchID prompt

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1340,8 +1340,13 @@ options:NSNumericSearch] != NSOrderedAscending)
 
 
 - (void)_resetTextFields {
-    if (![_passcodeTextField isFirstResponder] && (!_isUsingTouchID || _useFallbackPasscode)) {
-        [_passcodeTextField becomeFirstResponder];
+    if (![_passcodeTextField isFirstResponder] && (!(_isUsingTouchID || _allowUnlockWithTouchID) || _useFallbackPasscode)) {
+        //It seems like there's a glitch with how the alert gets removed when hitting
+        //cancel in the TouchID prompt. In some cases, the keyboard is present, but invisible
+        //after dismissing the alert unless we call becomeFirstResponder with a short delay
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [_passcodeTextField becomeFirstResponder];
+        });
     }
     _firstDigitTextField.secureTextEntry = NO;
     _secondDigitTextField.secureTextEntry = NO;


### PR DESCRIPTION
In 3.7.7, in some cases when you hit cancel on TouchID from the lock screen, the keyboard will not become visible (it's still present - you can hit keys - but not displayed).

I'm able to reproduce this on several devices and this seems to fix it. Moving the ```[self _resetUI]``` call is necessary so the code correctly sets the TouchID settings before the first UI reset, otherwise the keyboard appears briefly with the TouchID prompt as the ```_passwordTextField``` becomes the responder in ```_resetUI``` and then vanishes again as the ```_passwordTextField``` loses first responder status.

I dislike using ```dispatch_after``` like this, but I couldn't find a better way around it in this case.