### PR TITLE
Added support for iOS App Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.8.9
+* Added support for iOS App Extensions:
+	* Now, if you add a macro to project settings (LTH_APP_EXTENSIONS), LTHPasscode doesn’t crash. Also, with a new method, you can provide the size of the view in which the LHTPasscode view is going to be presented.
+
 # 3.8.8
 * Fixed translations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.8.9
 * Added support for iOS App Extensions:
-	* Now, if you add a macro to project settings (LTH_APP_EXTENSIONS), LTHPasscode doesn’t crash. Also, with a new method, you can provide the size of the view in which the LHTPasscode view is going to be presented.
+	* Now, if you add a macro to project settings (`LTH_APP_EXTENSIONS`), `LTHPasscodeViewController` doesn’t crash under an extension target.
+	* Also, with a new method, you can provide a view in which the lock is going to be presented and centered in.
 
 # 3.8.8
 * Fixed translations.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -319,7 +319,7 @@
  @param hasLogout   Set to @c YES for a navBar with a Logout button, set to @c NO for no navBar.
  @param logoutTitle The title of the Logout button.
  */
-- (void)showLockScreenIntoSuperview:(UIView *)superview WithAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle;
+- (void)showLockScreenIntoSuperview:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle;
 /**
  @brief				   Used for enabling the passcode.
  @details              The back bar button is hidden by default. Set @c hidesBackButton to @c NO if you want it to be visible.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -314,6 +314,13 @@
  */
 - (void)showLockScreenWithAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle;
 /**
+ @brief				Used for displaying the lock. The passcode view is added directly on the keyWindow.
+ @param superview   The superview where is to be presented, used to measure the center of the view.
+ @param hasLogout   Set to @c YES for a navBar with a Logout button, set to @c NO for no navBar.
+ @param logoutTitle The title of the Logout button.
+ */
+- (void)showLockScreenIntoSuperview:(UIView *)superview WithAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle;
+/**
  @brief				   Used for enabling the passcode.
  @details              The back bar button is hidden by default. Set @c hidesBackButton to @c NO if you want it to be visible.
  @param	viewController The view controller where the passcode view controller will be displayed.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -319,7 +319,7 @@
  @param hasLogout   Set to @c YES for a navBar with a Logout button, set to @c NO for no navBar.
  @param logoutTitle The title of the Logout button.
  */
-- (void)showLockScreenIntoSuperview:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle;
+- (void)showLockScreenOver:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle;
 /**
  @brief				   Used for enabling the passcode.
  @details              The back bar button is hidden by default. Set @c hidesBackButton to @c NO if you want it to be visible.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1051,6 +1051,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                     LTHMainWindow.center.y + self.navigationController.navigationBar.frame.size.height / 2);
         }
     }
+    
     [UIView animateWithDuration: animated ? _lockAnimationDuration : 0 animations: ^{
         self.view.center = newCenter;
     }];
@@ -1105,6 +1106,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                     superviewCenter.y + self.navigationController.navigationBar.frame.size.height / 2);
         }
     }
+    
     [UIView animateWithDuration: animated ? _lockAnimationDuration : 0 animations: ^{
         self.view.center = newCenter;
     }];

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1010,60 +1010,10 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 }
 
 - (void)showLockScreenWithAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle {
-    [self _prepareAsLockScreen];
-    
-    // In case the user leaves the app while the lockscreen is already active.
-    if (_isCurrentlyOnScreen) { return; }
-    _isCurrentlyOnScreen = YES;
-    
-    [LTHMainWindow addSubview: self.view];
-    
-    // All this hassle because a view added to UIWindow does not rotate automatically
-    // and if we would have added the view anywhere else, it wouldn't display properly
-    // (having a modal on screen when the user leaves the app, for example).
-    [self rotateAccordingToStatusBarOrientationAndSupportedOrientations];
-    CGPoint newCenter;
-    [self statusBarFrameOrOrientationChanged:nil];
-    if (LTHiOS8) {
-        self.view.center = CGPointMake(self.view.center.x, self.view.center.y * -1.f);
-        newCenter = CGPointMake(LTHMainWindow.center.x,
-                                LTHMainWindow.center.y + self.navigationController.navigationBar.frame.size.height / 2);
-    }
-    else {
-        if ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeLeft) {
-            self.view.center = CGPointMake(self.view.center.x * -1.f, self.view.center.y);
-            newCenter = CGPointMake(LTHMainWindow.center.x - self.navigationController.navigationBar.frame.size.height / 2,
-                                    LTHMainWindow.center.y);
-        }
-        else if ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeRight) {
-            self.view.center = CGPointMake(self.view.center.x * 2.f, self.view.center.y);
-            newCenter = CGPointMake(LTHMainWindow.center.x + self.navigationController.navigationBar.frame.size.height / 2,
-                                    LTHMainWindow.center.y);
-        }
-        else if ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationPortrait) {
-            self.view.center = CGPointMake(self.view.center.x, self.view.center.y * -1.f);
-            newCenter = CGPointMake(LTHMainWindow.center.x,
-                                    LTHMainWindow.center.y - self.navigationController.navigationBar.frame.size.height / 2);
-        }
-        else {
-            self.view.center = CGPointMake(self.view.center.x, self.view.center.y * 2.f);
-            newCenter = CGPointMake(LTHMainWindow.center.x,
-                                    LTHMainWindow.center.y + self.navigationController.navigationBar.frame.size.height / 2);
-        }
-    }
-    
-    [UIView animateWithDuration: animated ? _lockAnimationDuration : 0 animations: ^{
-        self.view.center = newCenter;
-    }];
-    
-    // Add nav bar & logout button if specified
-    if (hasLogout) {
-        _isUsingNavBar = hasLogout;
-        [self _setupNavBarWithLogoutTitle:logoutTitle];
-    }
+    [self showLockScreenIntoSuperview:LTHMainWindow withAnimation:animated withLogout:hasLogout andLogoutTitle:logoutTitle];
 }
 
-- (void)showLockScreenIntoSuperview:(UIView *)superview WithAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle {
+- (void)showLockScreenIntoSuperview:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle {
     [self _prepareAsLockScreen];
     
     // In case the user leaves the app while the lockscreen is already active.
@@ -1076,7 +1026,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     // and if we would have added the view anywhere else, it wouldn't display properly
     // (having a modal on screen when the user leaves the app, for example).
     [self rotateAccordingToStatusBarOrientationAndSupportedOrientations];
-    CGPoint superviewCenter = CGPointMake(superview.frame.size.width/2, superview.frame.size.height/2);
+    CGPoint superviewCenter = CGPointMake(superview.center.x, superview.center.y);
     CGPoint newCenter;
     [self statusBarFrameOrOrientationChanged:nil];
     if (LTHiOS8) {

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1010,10 +1010,10 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 }
 
 - (void)showLockScreenWithAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle {
-    [self showLockScreenIntoSuperview:LTHMainWindow withAnimation:animated withLogout:hasLogout andLogoutTitle:logoutTitle];
+    [self showLockScreenOver:LTHMainWindow withAnimation:animated withLogout:hasLogout andLogoutTitle:logoutTitle];
 }
 
-- (void)showLockScreenIntoSuperview:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle {
+- (void)showLockScreenOver:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString*)logoutTitle {
     [self _prepareAsLockScreen];
     
     // In case the user leaves the app while the lockscreen is already active.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1842,12 +1842,12 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     CGFloat angle = UIInterfaceOrientationAngleOfOrientation(orientation);
     CGAffineTransform transform = CGAffineTransformMakeRotation(angle);
     
-    [self setIfNotEqualTransform: transform
-                           frame: self.view.window.bounds];
+    [self setIfNotEqualTransform: transform];
 }
 
 
-- (void)setIfNotEqualTransform:(CGAffineTransform)transform frame:(CGRect)frame {
+- (void)setIfNotEqualTransform:(CGAffineTransform)transform {
+    CGRect frame = self.view.superview.frame;
     if(!CGAffineTransformEqualToTransform(self.view.transform, transform)) {
         self.view.transform = transform;
     }


### PR DESCRIPTION
Now, if you add a macro to project settings (LTH_APP_EXTENSIONS), LTHPasscode doesn’t crash. Also, with a new method, you can provide the size of the view in which the LHTPasscode view is going to be presented.