### PR TITLE
Added method to reset passcode, useful when using app extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.8.10
+* Added new method to reset passcode `- (void)resetPasscode`, useful when using app extensions.
+
 # 3.8.9
 * Added support for iOS App Extensions: defining `LTH_IS_APP_EXTENSION` for an extension target will fix `LTHPasscodeViewController` crashing.
 * Added new method: `- (void)showLockScreenOver:(UIView *)superview withAnimation:(BOOL)animated withLogout:(BOOL)hasLogout andLogoutTitle:(NSString *)logoutTitle`. Used to provide a view in which the lock is going to be presented, sized to and centered in.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.h
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.h
@@ -416,5 +416,9 @@
  @brief  Returns the shared instance of the passcode view controller.
  */
 + (instancetype)sharedUser;
+/**
+ @brief  Resets the passcode.
+ */
+- (void)resetPasscode;
 
 @end

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -320,6 +320,15 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
                                               error:nil];
 }
 
+
+- (void)resetPasscode {
+    if ([self _doesPasscodeExist]) {
+        NSString *passcode = [self _passcode];
+        [self _deletePasscode];
+        [self _savePasscode:passcode];
+    }
+}
+
 #if !(TARGET_IPHONE_SIMULATOR)
 - (void)_handleTouchIDFailureAndDisableTouchID:(BOOL)disableTouchID {
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Imagine this scenario: a user has a passcode set in an app. The app updates and includes a new extension. The app would require the passcode, but not the extension. This is because the passcode is saved in the standard keychain of the app, but is common to move to a shared keychain when using extensions (for example, to share the passcode with the extensions).

The keychain used is transparent for `LTHPasscodeViewController`, but if a developer wants to migrate to a shared keychain, the passcode must be reset (when stored again, if the shared keychain is enabled, the passcode will be stored there, and so available to both the app and the extensions, current and future).

The developer should add something like this when starting the main app to make the current passcode available for the extensions (and reset it only once):
```
if (![sharedUserDefaults boolForKey:@"extensions-passcode"]) {
    [[LTHPasscodeViewController sharedUser] resetPasscode];
    [sharedUserDefaults setBool:YES forKey:@"extensions-passcode"];
}
```
About keychain sharing: https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW15