### PR TITLE
Fix issue #185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.8.11
+* Fixed navigation bar layout when present passcode with logout enabled in iOS11.
+
 # 3.8.10
 * Added new method to reset passcode `- (void)resetPasscode`, useful when using app extensions.
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -12,6 +12,8 @@
 
 #define LTHiOS8 ([[[UIDevice currentDevice] systemVersion] compare:@"8.0" \
 options:NSNumericSearch] != NSOrderedAscending)
+#define LTHiOS11 ([[[UIDevice currentDevice] systemVersion] compare:@"11.0" \
+options:NSNumericSearch] != NSOrderedAscending)
 #define LTHiPad (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
@@ -457,6 +459,14 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
     [self _setupDigitFields];
 }
 
+- (void)setStatusBarBackgroundColor:(UIColor *)color {
+    
+    UIView *statusBar = [[[UIApplication sharedApplication] valueForKey:@"statusBarWindow"] valueForKey:@"statusBar"];
+    
+    if ([statusBar respondsToSelector:@selector(setBackgroundColor:)]) {
+        statusBar.backgroundColor = color;
+    }
+}
 
 #pragma mark - View life
 - (void)viewDidLoad {
@@ -618,9 +628,18 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 #pragma mark - UI setup
 - (void)_setupNavBarWithLogoutTitle:(NSString *)logoutTitle {
     // Navigation Bar with custom UI
-    self.navBar =
-    [[UINavigationBar alloc] initWithFrame:CGRectMake(0, LTHMainWindow.frame.origin.y,
-                                                      LTHMainWindow.frame.size.width, 64)];
+    if (LTHiOS11) {
+        self.navBar =
+        [[UINavigationBar alloc] initWithFrame:CGRectMake(0, [LTHPasscodeViewController getStatusBarHeight],
+                                                          LTHMainWindow.frame.size.width, 64)];
+        [self setStatusBarBackgroundColor:[UIColor whiteColor]];
+    }
+    else {
+        self.navBar =
+        [[UINavigationBar alloc] initWithFrame:CGRectMake(0, LTHMainWindow.frame.origin.y,
+                                                          LTHMainWindow.frame.size.width, 64)];
+    }
+    
     self.navBar.tintColor = self.navigationTintColor;
     if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)]) {
         self.navBar.barTintColor = self.navigationBarTintColor;


### PR DESCRIPTION
With this change the navigation bar height will be layout correctly in iOS11. The main change is that when iOS11 the origin.y starts at status bar height value