### PR TITLE
Status bar height issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.9.2
+* Fixed wrong status bar height in landscape orientation.
+
 # 3.9.1
 * Fixed navigation bar layout when present passcode with logout enabled in iOS11.
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -1895,13 +1895,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 
 + (CGFloat)getStatusBarHeight {
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-    if (UIInterfaceOrientationIsLandscape(orientation)) {
-        return [UIApplication sharedApplication].statusBarFrame.size.width;
-    }
-    else {
-        return [UIApplication sharedApplication].statusBarFrame.size.height;
-    }
+    return [UIApplication sharedApplication].statusBarFrame.size.height;
 }
 
 


### PR DESCRIPTION
Hi! Checking the behavior a bit more detailed, I have found that when the LTHPasscodeViewController is shown with the navigation bar in landscape mode, the status bar height is returned as its width, do not know why, maybe old iOS versions... but in our app, that allows screen rotation, if you start the app in landscape, the patch view created in the previous pull request gets a height of the status bar width (this is screen width), so it is a withe view filling all the screen. 