### PR TITLE
Demo crashes because the key NSFaceIDUsageDescription is required

### DIFF
--- a/Demo/LTHPasscodeViewController Demo/LTHPasscodeViewController Demo-Info.plist
+++ b/Demo/LTHPasscodeViewController Demo/LTHPasscodeViewController Demo-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>LTHPasscodeViewControllerDemo accesses Face ID to allow you to easily unlock the app’s passcode when you enable this option.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
[access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSFaceIDUsageDescription key with a string value explaining to the user how the app uses this data.