### PR TITLE
Avoid a crash in iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.9.4
+* Avoid a crash in iOS 13 accessing the first object of the windows.
+
 # 3.9.3
 * Fixed a crash in demo project.
 * Removed unused string.

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -50,7 +50,7 @@ options:NSNumericSearch] != NSOrderedAscending)
 #ifdef LTH_IS_APP_EXTENSION
 #define LTHMainWindow [UIApplication sharedApplication].keyWindow
 #else
-#define LTHMainWindow [UIApplication sharedApplication].windows[0]
+#define LTHMainWindow [UIApplication sharedApplication].windows.firstObject
 #endif
 
 @interface LTHPasscodeViewController () <UITextFieldDelegate>


### PR DESCRIPTION
Use firstObject instead [0] when accessing the first element of the windows array.

firstObject returns nil if there is none. Using [0] or objectAtIndex:0 will crash if there is no object there.

We received some crashes in iOS 13 when the application tries to access the first object of the windows array. The code tries to mitigate this crash.