### PR TITLE
Adds Support for Swift Package Manager

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -24,7 +24,7 @@
 
 #ifndef LTHPasscodeViewControllerStrings
 #define LTHPasscodeViewControllerStrings(key) [LTHLocalizedString(key) length] == 0 \
-    ? [[NSBundle bundleWithPath: [SWIFTPM_MODULE_BUNDLE pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(@"Unlock using Touch ID") value:@"" table:_localizationTableName] \
+    ? [[NSBundle bundleWithPath: [SWIFTPM_MODULE_BUNDLE pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] \
     : LTHLocalizedString(key)
 #endif
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -14,11 +14,22 @@
 
 #define LTHFailedAttemptLabelHeight [_failedAttemptLabel.text sizeWithAttributes: @{NSFontAttributeName : _labelFont}].height
 
+//#ifndef LTHPasscodeViewControllerStrings
+//#define LTHPasscodeViewControllerStrings(key) \
+//NSString *localizedString = [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] \
+//printf(localizedString); \
+//if ([localizedString length] == 0) { \
+//    printf([SWIFTPM_MODULE_BUNDLE localizedStringForKey: (key) value:@"" table:_localizationTableName]); \
+//    return [SWIFTPM_MODULE_BUNDLE localizedStringForKey: (key) value:@"" table:_localizationTableName] \
+//} else { \
+//    return localizedString \
+//}
+//#endif
+
 #ifndef LTHPasscodeViewControllerStrings
 #define LTHPasscodeViewControllerStrings(key) \
-[[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName]
+[[[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] length] == 0 ? [SWIFTPM_MODULE_BUNDLE localizedStringForKey: (key) value:@"" table:_localizationTableName] : [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName]
 #endif
-
 // MARK: Please read
 /*
  Using windows[0] instead of keyWindow due to an issue with UIAlertViews / UIActionSheets - displaying the lockscreen when an alertView / actionSheet is visible, or displaying one after the lockscreen is visible results in a few cases:
@@ -147,6 +158,7 @@ static const NSInteger LTHMaxPasscodeDigits = 10;
 
 
 #pragma mark - Private methods
+
 - (void)_close {
     if (_displayedAsLockScreen) [self _dismissMe];
     else [self _cancelAndDismissMe];

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -20,7 +20,7 @@
 
 #ifndef LTHPasscodeViewControllerStrings
 #define LTHPasscodeViewControllerStrings(key) [LTHLocalizedString(key) length] == 0 \
-    ? [SWIFTPM_MODULE_BUNDLE localizedStringForKey:key value:@"" table:_localizationTableName] \
+    ? [[NSBundle bundleWithPath: [SWIFTPM_MODULE_BUNDLE pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(@"Unlock using Touch ID") value:@"" table:_localizationTableName] \
     : LTHLocalizedString(key)
 #endif
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -14,22 +14,11 @@
 
 #define LTHFailedAttemptLabelHeight [_failedAttemptLabel.text sizeWithAttributes: @{NSFontAttributeName : _labelFont}].height
 
-//#ifndef LTHPasscodeViewControllerStrings
-//#define LTHPasscodeViewControllerStrings(key) \
-//NSString *localizedString = [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] \
-//printf(localizedString); \
-//if ([localizedString length] == 0) { \
-//    printf([SWIFTPM_MODULE_BUNDLE localizedStringForKey: (key) value:@"" table:_localizationTableName]); \
-//    return [SWIFTPM_MODULE_BUNDLE localizedStringForKey: (key) value:@"" table:_localizationTableName] \
-//} else { \
-//    return localizedString \
-//}
-//#endif
-
 #ifndef LTHPasscodeViewControllerStrings
 #define LTHPasscodeViewControllerStrings(key) \
-[[[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] length] == 0 ? [SWIFTPM_MODULE_BUNDLE localizedStringForKey: (key) value:@"" table:_localizationTableName] : [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName]
+[[[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] length] == 0 ? NSLocalizedString(key, bundle: .module, comment: "") : [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName]
 #endif
+
 // MARK: Please read
 /*
  Using windows[0] instead of keyWindow due to an issue with UIAlertViews / UIActionSheets - displaying the lockscreen when an alertView / actionSheet is visible, or displaying one after the lockscreen is visible results in a few cases:

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -10,6 +10,10 @@
 #import "LTHKeychainUtils.h"
 #import <LocalAuthentication/LocalAuthentication.h>
 
+#ifndef SWIFTPM_MODULE_BUNDLE
+#define SWIFTPM_MODULE_BUNDLE [NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]]
+#endif
+
 #define LTHiPad ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
 
 #define LTHFailedAttemptLabelHeight [_failedAttemptLabel.text sizeWithAttributes: @{NSFontAttributeName : _labelFont}].height

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -20,7 +20,7 @@
 
 #ifndef LTHPasscodeViewControllerStrings
 #define LTHPasscodeViewControllerStrings(key) [LTHLocalizedString(key) length] == 0 \
-    ? NSLocalizedString(key, bundle: .module) \
+    ? [SWIFTPM_MODULE_BUNDLE localizedStringForKey:key value:@"" table:_localizationTableName] \
     : LTHLocalizedString(key)
 #endif
 

--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -14,9 +14,14 @@
 
 #define LTHFailedAttemptLabelHeight [_failedAttemptLabel.text sizeWithAttributes: @{NSFontAttributeName : _labelFont}].height
 
+#ifndef LTHLocalizedString
+#define LTHLocalizedString(key) [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName]
+#endif
+
 #ifndef LTHPasscodeViewControllerStrings
-#define LTHPasscodeViewControllerStrings(key) \
-[[[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName] length] == 0 ? NSLocalizedString(key, bundle: .module, comment: "") : [[NSBundle bundleWithPath:[[NSBundle bundleForClass:[LTHPasscodeViewController class]] pathForResource:@"LTHPasscodeViewController" ofType:@"bundle"]] localizedStringForKey:(key) value:@"" table:_localizationTableName]
+#define LTHPasscodeViewControllerStrings(key) [LTHLocalizedString(key) length] == 0 \
+    ? NSLocalizedString(key, bundle: .module) \
+    : LTHLocalizedString(key)
 #endif
 
 // MARK: Please read

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "LTHPasscodeViewController",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "LTHPasscodeViewController",
+            targets: ["LTHPasscodeViewController"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "LTHPasscodeViewController",
+            path: ".",
+            exclude: ["Demo", "CHANGELOG.md", "LICENSE.txt", "README.md"],
+            sources: ["LTHPasscodeViewController/LTHKeychainUtils.h", "LTHPasscodeViewController/LTHKeychainUtils.m", "LTHPasscodeViewController/LTHPasscodeViewController.h", "LTHPasscodeViewController/LTHPasscodeViewController.m"],
+            resources: [.copy("Localizations")],
+            publicHeadersPath: "LTHPasscodeViewController"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,11 @@ let package = Package(
         .target(
             name: "LTHPasscodeViewController",
             path: ".",
-            exclude: ["Demo", "CHANGELOG.md", "LICENSE.txt", "README.md"],
-            resources: [.process("Localizations/LTHPasscodeViewController.bundle")],
+            exclude: ["Demo", "CHANGELOG.md", "README.md"],
+            resources: [
+                .process("Localizations/LTHPasscodeViewController.bundle"),
+                .process("LICENSE.txt")
+            ],
             publicHeadersPath: "LTHPasscodeViewController"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
             name: "LTHPasscodeViewController",
             path: ".",
             exclude: ["Demo", "CHANGELOG.md", "LICENSE.txt", "README.md"],
-            sources: ["LTHPasscodeViewController/LTHKeychainUtils.h", "LTHPasscodeViewController/LTHKeychainUtils.m", "LTHPasscodeViewController/LTHPasscodeViewController.h", "LTHPasscodeViewController/LTHPasscodeViewController.m"],
             resources: [.process("Localizations/LTHPasscodeViewController.bundle")],
             publicHeadersPath: "LTHPasscodeViewController"
         )

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "LTHPasscodeViewController",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v10)
     ],
@@ -18,7 +19,7 @@ let package = Package(
             path: ".",
             exclude: ["Demo", "CHANGELOG.md", "LICENSE.txt", "README.md"],
             sources: ["LTHPasscodeViewController/LTHKeychainUtils.h", "LTHPasscodeViewController/LTHKeychainUtils.m", "LTHPasscodeViewController/LTHPasscodeViewController.h", "LTHPasscodeViewController/LTHPasscodeViewController.m"],
-            resources: [.copy("Localizations")],
+            resources: [.process("Localizations/LTHPasscodeViewController.bundle")],
             publicHeadersPath: "LTHPasscodeViewController"
         )
     ]

--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ Simple to use iOS 7 style Passcode - the one you get in Settings when changing y
 
 # Installation
 
-### CocoaPods
-
-[CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate LTHPasscodeViewController into your Xcode project using CocoaPods, specify it in your `Podfile`:
-
-```ruby
-pod 'LTHPasscodeViewController', '~> 4.0.1'
-```
-
 ### Swift Package Manager
 
 __NOTE__: _These instructions are intended for usage on Xcode 11 and higher. Xcode 11 is the first version of Xcode that integrates Swift Package manager and makes it way easier to use than it was at the command line. If you are using older versions of Xcode, we recommend using CocoaPods._
 
 1. Go to File > Swift Packages > Add Package Dependency...
-2. Paste the URL to the LTHPasscodeViewController repo on GitHub (https://github.com/rolandleth/LTHPasscodeViewController.git) into the search bar, then hit the Next button:
+2. Paste the URL to the `LTHPasscodeViewController` repo on GitHub (https://github.com/rolandleth/LTHPasscodeViewController.git) into the search bar, then hit the Next button:
 3. Select what version you want to use, then hit next (Xcode will automatically suggest the current version Up to Next Major).
 4. Select the `LTHPasscodeViewController` library and then hit finish.
 5. You're done!
+
+### CocoaPods
+
+[CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate `LTHPasscodeViewController` into your Xcode project using CocoaPods, specify it in your `Podfile`:
+
+```ruby
+pod 'LTHPasscodeViewController', '~> 4.0.1'
+```
 
 ### Manually
 
@@ -69,7 +69,7 @@ if ([LTHPasscodeViewController doesPasscodeExist]) {
 
 ```objc
 /**
- @param    viewController The view controller where the passcode view controller will be displayed.
+ @param viewController The view controller where the passcode view controller will be displayed.
  @param asModal        Set to YES to present as a modal, or to NO to push on the current nav stack.
  */
 - (void)showForEnablingPasscodeInViewController:(UIViewController *)viewController asModal:(BOOL)isModal;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
 # LTHPasscodeViewController
 Simple to use iOS 7 style Passcode - the one you get in Settings when changing your passcode.
 
+# Installation
+
+### CocoaPods
+
+[CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate LTHPasscodeViewController into your Xcode project using CocoaPods, specify it in your `Podfile`:
+
+```ruby
+pod 'LTHPasscodeViewController', '~> 4.0.1'
+```
+
+### Swift Package Manager
+
+__NOTE__: _These instructions are intended for usage on Xcode 11 and higher. Xcode 11 is the first version of Xcode that integrates Swift Package manager and makes it way easier to use than it was at the command line. If you are using older versions of Xcode, we recommend using CocoaPods._
+
+1. Go to File > Swift Packages > Add Package Dependency...
+2. Paste the URL to the LTHPasscodeViewController repo on GitHub (https://github.com/rolandleth/LTHPasscodeViewController.git) into the search bar, then hit the Next button:
+3. Select what version you want to use, then hit next (Xcode will automatically suggest the current version Up to Next Major).
+4. Select the `LTHPasscodeViewController` library and then hit finish.
+5. You're done!
+
+### Manually
+
+Simply clone the repo and drag the contents of `LTHPasscodeViewController` to your project.
+
 # How to use
-Drag the contents of `LTHPasscodeViewController` to your project, or add `pod 'LTHPasscodeViewController'` to your Podfile (preffered).
 
 If your app uses extensions, `LTH_IS_APP_EXTENSION` needs to be defined:
 
@@ -14,8 +37,8 @@ Example, called in `application:didFinishLaunchingWithOptions`:
 ```objc
 [LTHPasscodeViewController useKeychain:NO];
 if ([LTHPasscodeViewController doesPasscodeExist]) {
-	if ([LTHPasscodeViewController didPasscodeTimerEnd])
-		[[LTHPasscodeViewController sharedUser] showLockScreenWithAnimation:YES
+    if ([LTHPasscodeViewController didPasscodeTimerEnd])
+        [[LTHPasscodeViewController sharedUser] showLockScreenWithAnimation:YES
                                                                  withLogout:NO
                                                              andLogoutTitle:nil];
 }
@@ -46,7 +69,7 @@ if ([LTHPasscodeViewController doesPasscodeExist]) {
 
 ```objc
 /**
- @param	viewController The view controller where the passcode view controller will be displayed.
+ @param    viewController The view controller where the passcode view controller will be displayed.
  @param asModal        Set to YES to present as a modal, or to NO to push on the current nav stack.
  */
 - (void)showForEnablingPasscodeInViewController:(UIViewController *)viewController asModal:(BOOL)isModal;


### PR DESCRIPTION
Adds support for SPM. See README.md for instructions on how to add it to your project.

Finally got around to fixing this up again. Now that Apple supports Resources I was able to import the Localizations. I added to the LTHPasscodeViewControllerStrings method to search for the SPM bundle if it didn't find a localized string since Apple moves those localizations into its own bundle.