### PR TITLE
Add Package.swift to target exclude list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "LTHPasscodeViewController",
             path: ".",
-            exclude: ["Demo", "CHANGELOG.md", "README.md"],
+            exclude: ["Demo", "CHANGELOG.md", "README.md", "Package.swift"],
             resources: [
                 .process("Localizations/LTHPasscodeViewController.bundle"),
                 .process("LICENSE.txt")


### PR DESCRIPTION
Hello!

I am using this library through [Tuist](https://tuist.dev/), but when trying to use it via Tuist's SPM, the Package.swift file gets included, resulting in the error: no such module 'PackageDescription'.

<img width="390" alt="image" src="https://github.com/user-attachments/assets/c6d0ee87-a4d6-41ae-bca8-5f2b7d4ae93f" />
<img width="1851" alt="image" src="https://github.com/user-attachments/assets/23ac051b-2adb-43b2-88d3-d72b140dc999" />
<img width="373" alt="image" src="https://github.com/user-attachments/assets/301e54da-a3e5-4bed-b63e-76a9a3745503" />


With this commit, I am excluding the Package.swift file from the target sources to resolve the issue.

Please review it! Thanks:)